### PR TITLE
让SolutionSelectionFunction接受对应的Request作为输入

### DIFF
--- a/moveit_ros/planning/planning_pipeline_interfaces/include/moveit/planning_pipeline_interfaces/plan_responses_container.hpp
+++ b/moveit_ros/planning/planning_pipeline_interfaces/include/moveit/planning_pipeline_interfaces/plan_responses_container.hpp
@@ -44,6 +44,10 @@ namespace moveit
 {
 namespace planning_pipeline_interfaces
 {
+
+typedef std::tuple<::planning_interface::MotionPlanRequest, ::planning_interface::MotionPlanResponse>
+    MotionPlanRequestAndResponse;
+
 MOVEIT_CLASS_FORWARD(PlanResponsesContainer);  // Defines PlanningComponentPtr, ConstPtr, WeakPtr... etc
 /** \brief A container to thread-safely store multiple MotionPlanResponses */
 class PlanResponsesContainer
@@ -59,15 +63,20 @@ public:
    * This way, it is possible to create a sorted container e.g. according to a user specified criteria
    * \param [in] plan_solution MotionPlanResponse to push back into the vector
    */
-  void pushBack(const ::planning_interface::MotionPlanResponse& plan_solution);
+  void pushBack(const MotionPlanRequestAndResponse& plan_solution);
 
   /** \brief Get solutions
    * \return Read-only access to the responses vector
    */
-  const std::vector<::planning_interface::MotionPlanResponse>& getSolutions() const;
+  const std::vector<::planning_interface::MotionPlanResponse> getSolutions() const;
+
+  /** \brief Get request and solutions
+   * \return Read-only access to the responses vector
+   */
+  const std::vector<MotionPlanRequestAndResponse>& getRequestAndSolutions() const;
 
 private:
-  std::vector<::planning_interface::MotionPlanResponse> solutions_;
+  std::vector<MotionPlanRequestAndResponse> solutions_;
   std::mutex solutions_mutex_;
 };
 }  // namespace planning_pipeline_interfaces

--- a/moveit_ros/planning/planning_pipeline_interfaces/include/moveit/planning_pipeline_interfaces/plan_responses_container.hpp
+++ b/moveit_ros/planning/planning_pipeline_interfaces/include/moveit/planning_pipeline_interfaces/plan_responses_container.hpp
@@ -68,7 +68,7 @@ public:
   /** \brief Get solutions
    * \return Read-only access to the responses vector
    */
-  const std::vector<::planning_interface::MotionPlanResponse> getSolutions() const;
+  const std::vector<::planning_interface::MotionPlanResponse>& getSolutions() const;
 
   /** \brief Get request and solutions
    * \return Read-only access to the responses vector

--- a/moveit_ros/planning/planning_pipeline_interfaces/include/moveit/planning_pipeline_interfaces/planning_pipeline_interfaces.hpp
+++ b/moveit_ros/planning/planning_pipeline_interfaces/include/moveit/planning_pipeline_interfaces/planning_pipeline_interfaces.hpp
@@ -60,8 +60,7 @@ typedef std::function<bool(const PlanResponsesContainer& plan_responses_containe
  * \param [in] solutions Motion plan responses to choose from
  * \return Selected motion plan response
  */
-typedef std::function<::planning_interface::MotionPlanResponse(
-    const std::vector<::planning_interface::MotionPlanResponse>& solutions)>
+typedef std::function<::planning_interface::MotionPlanResponse(const std::vector<MotionPlanRequestAndResponse>& solutions)>
     SolutionSelectionFunction;
 
 /** \brief Function to calculate the MotionPlanResponse for a given MotionPlanRequest and a PlanningScene

--- a/moveit_ros/planning/planning_pipeline_interfaces/include/moveit/planning_pipeline_interfaces/solution_selection_functions.hpp
+++ b/moveit_ros/planning/planning_pipeline_interfaces/include/moveit/planning_pipeline_interfaces/solution_selection_functions.hpp
@@ -47,8 +47,7 @@ namespace planning_pipeline_interfaces
  *  \param [in] solutions Vector of solutions to chose the shortest one from
  *  \return Shortest solution, trajectory of the returned MotionPlanResponse is a nullptr if no solution is found!
  */
-::planning_interface::MotionPlanResponse
-getShortestSolution(const std::vector<::planning_interface::MotionPlanResponse>& solutions);
+::planning_interface::MotionPlanResponse getShortestSolution(const std::vector<MotionPlanRequestAndResponse>& solutions);
 
 }  // namespace planning_pipeline_interfaces
 }  // namespace moveit

--- a/moveit_ros/planning/planning_pipeline_interfaces/src/plan_responses_container.cpp
+++ b/moveit_ros/planning/planning_pipeline_interfaces/src/plan_responses_container.cpp
@@ -46,13 +46,27 @@ PlanResponsesContainer::PlanResponsesContainer(const size_t expected_size)
   solutions_.reserve(expected_size);
 }
 
-void PlanResponsesContainer::pushBack(const ::planning_interface::MotionPlanResponse& plan_solution)
+void PlanResponsesContainer::pushBack(const MotionPlanRequestAndResponse& plan_solution)
 {
   std::lock_guard<std::mutex> lock_guard(solutions_mutex_);
   solutions_.push_back(plan_solution);
 }
 
-const std::vector<::planning_interface::MotionPlanResponse>& PlanResponsesContainer::getSolutions() const
+const std::vector<::planning_interface::MotionPlanResponse> PlanResponsesContainer::getSolutions() const
+{
+  // Otherwise, just return the unordered list of solutions
+  std::vector<::planning_interface::MotionPlanResponse> output;
+  output.reserve(solutions_.size());  // 预分配空间以提高效率
+
+  for (const auto& tuple : solutions_)
+  {
+    // 提取元组的第二个元素（索引1）
+    output.push_back(std::get<1>(tuple));
+  }
+  return output;
+}
+
+const std::vector<MotionPlanRequestAndResponse>& PlanResponsesContainer::getRequestAndSolutions() const
 {
   return solutions_;
 }

--- a/moveit_ros/planning/planning_pipeline_interfaces/src/planning_pipeline_interfaces.cpp
+++ b/moveit_ros/planning/planning_pipeline_interfaces/src/planning_pipeline_interfaces.cpp
@@ -38,6 +38,7 @@
 #include <moveit/utils/logger.hpp>
 
 #include <thread>
+#include <tuple>
 
 namespace moveit
 {
@@ -116,7 +117,7 @@ const std::vector<::planning_interface::MotionPlanResponse> planWithParallelPipe
         plan_solution.error_code = moveit::core::MoveItErrorCode::FAILURE;
       }
       plan_solution.planner_id = request.planner_id;
-      plan_responses_container.pushBack(plan_solution);
+      plan_responses_container.pushBack(std::make_tuple(request, plan_solution));
 
       if (stopping_criterion_callback != nullptr)
       {
@@ -160,11 +161,10 @@ const std::vector<::planning_interface::MotionPlanResponse> planWithParallelPipe
   {
     std::vector<::planning_interface::MotionPlanResponse> solutions;
     solutions.reserve(1);
-    solutions.push_back(solution_selection_function(plan_responses_container.getSolutions()));
+    solutions.push_back(solution_selection_function(plan_responses_container.getRequestAndSolutions()));
     return solutions;
   }
 
-  // Otherwise, just return the unordered list of solutions
   return plan_responses_container.getSolutions();
 }
 

--- a/moveit_ros/planning/planning_pipeline_interfaces/src/solution_selection_functions.cpp
+++ b/moveit_ros/planning/planning_pipeline_interfaces/src/solution_selection_functions.cpp
@@ -35,14 +35,21 @@
 /* Author: Sebastian Jahr */
 
 #include <moveit/planning_pipeline_interfaces/solution_selection_functions.hpp>
+#include <vector>
+#include "moveit/planning_pipeline_interfaces/plan_responses_container.hpp"
 
 namespace moveit
 {
 namespace planning_pipeline_interfaces
 {
-::planning_interface::MotionPlanResponse
-getShortestSolution(const std::vector<::planning_interface::MotionPlanResponse>& solutions)
+::planning_interface::MotionPlanResponse getShortestSolution(const std::vector<MotionPlanRequestAndResponse>& results)
 {
+  std::vector<::planning_interface::MotionPlanResponse> solutions;
+  solutions.reserve(results.size());
+  for (const auto& tuple : results)
+  {
+    solutions.push_back(std::get<1>(tuple));
+  }
   // Find trajectory with minimal path
   const auto shortest_trajectory = std::min_element(solutions.begin(), solutions.end(),
                                                     [](const ::planning_interface::MotionPlanResponse& solution_a,


### PR DESCRIPTION
- PlanResponsesContainer中原有的solution_改为std::tuple<::planning_interface::MotionPlanRequest, ::planning_interface::MotionPlanResponse>
- SolutionSelectionFunction从只接收Response改为接收tuple of Request and Response

需要rebuild moveit_ros_planning和moveit_py两个包